### PR TITLE
aatf pes16 support settings

### DIFF
--- a/VTL7/aatf.cpp
+++ b/VTL7/aatf.cpp
@@ -1066,6 +1066,51 @@ void aatf_single(HWND hAatfbox, int pesVersion, int teamSel, player_entry* gplay
         errorTot++;
         errorMsg << _T("Number of Gold medals is ") << numGold << _T(", should be ") << reqNumGold << _T("; ");
     }
+	if (pesVersion == 16)
+	{
+		for(int ii=0; ii<11; ii++)
+		{ if(gteams[teamSel].ManMarking1[ii] != 255)
+			{
+				errorTot++;
+				errorMsg << _T("Man marking is set up on preset 1; ");
+				break;
+
+			}
+		}
+		for(int ii=0; ii<11; ii++)
+		{ if(gteams[teamSel].ManMarking2[ii] != 255)
+			{
+				errorTot++;
+				errorMsg << _T("Man marking is set up on preset 2; ");
+				break;
+
+			}
+		}
+		for(int ii=0; ii<11; ii++)
+		{ if(gteams[teamSel].ManMarking3[ii] != 255)
+			{
+				errorTot++;
+				errorMsg << _T("Man marking is set up on preset 3; ");
+				break;
+
+			}
+		}
+		if(gteams[teamSel].AutoSub!=0)
+			{
+				errorTot++;
+				errorMsg << _T("Auto subs are on; ");
+			}
+		if(gteams[teamSel].AutoOffside!=0)
+			{
+				errorTot++;
+				errorMsg << _T("Auto offside trap is on; ");
+			}
+		if(gteams[teamSel].AutoPresetTactics!=0)
+			{
+				errorTot++;
+				errorMsg << _T("Auto change preset tactics is on; ");
+			}
+	}	
 	if(errorMsg.rdbuf()->in_avail())
 		errorMsg << _T("\r\n");
 	errorMsg << _T("\r\nErrors: ") << errorTot << _T("\r\n");

--- a/VTL7/editor.h
+++ b/VTL7/editor.h
@@ -433,7 +433,6 @@ struct player_entry : player_export
 			this->def = pImport.def; 
 			this->gk = pImport.gk; //Goalkeeping 
 			this->drib = pImport.drib; //Dribbling 
-			this->mo_fk = pImport.mo_fk; //Motion: Free Kick
 			this->finish = pImport.finish; //Finishing 
 			this->lowpass = pImport.lowpass; //Low Pass 
 			this->loftpass = pImport.loftpass; //Lofted Pass 
@@ -489,7 +488,8 @@ struct player_entry : player_export
 			this->mo_hunchr = pImport.mo_hunchr; //Motion: Hunching (running) 
 			this->mo_pk = pImport.mo_pk; //Motion: Penalty Kick
 			this->mo_armr = pImport.mo_armr; //Motion: Arm Movement (running) 
-			this->mo_ck = pImport.mo_ck; //Motion: Corner Kick 
+			this->mo_ck = pImport.mo_ck; //Motion: Corner Kick
+			this->mo_fk = pImport.mo_fk; //Motion: Free Kick 
 			this->age = pImport.age; //Age 
 			this->b_edit_motion = pImport.b_edit_motion; //Motion edit
 			this->b_base_copy = pImport.b_base_copy; //Is Base Copy?
@@ -568,6 +568,15 @@ struct team_entry
 
 	bool b_changed;
 	bool b_show;
+
+	
+	int ManMarking1[11];
+	int ManMarking2[11];
+	int ManMarking3[11];
+
+	int AutoSub;
+	int AutoOffside;
+	int AutoPresetTactics;
 
 	//Constructor
 	team_entry()

--- a/VTL7/main.cpp
+++ b/VTL7/main.cpp
@@ -903,8 +903,19 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_GETTEXT, (WPARAM)(sizeof(oldName) / sizeof(oldName[0])), (LPARAM)oldName);
 
 						newName[0] = 0;
-						wcscat(newName, L"ccc9900ff");
-						wcscat(newName, oldName);
+						if (wcsncmp(oldName, L"ccc9900ff", 10) == 0 || wcsncmp(oldName, L"c51bbc4ff", 10) == 0) //name starts with the gold or silver color
+						{
+							std::wstring tempName(oldName);
+							tempName = tempName.substr(10); //remove the color part
+							wcscat(newName, L"ccc9900ff");
+							wcscat(newName, tempName.c_str());
+						}
+						else //name has no color
+						{
+							wcscat(newName, L"ccc9900ff");
+							wcscat(newName, oldName);
+
+						}
 
 						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_SETTEXT, 0, (LPARAM)newName);
 					}
@@ -963,9 +974,19 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_GETTEXT, (WPARAM)(sizeof(oldName) / sizeof(oldName[0])), (LPARAM)oldName);
 
 						newName[0] = 0;
-						wcscat(newName, L"c51bbc4ff");
+						if (wcsncmp(oldName, L"ccc9900ff", 10) == 0 || wcsncmp(oldName, L"c51bbc4ff", 10) == 0) //name starts with the gold or silver color
+						{
+							std::wstring tempName(oldName);
+							tempName = tempName.substr(10); //remove the color
+							wcscat(newName, L"c51bbc4ff");
+							wcscat(newName, tempName.c_str());
+						}
+						else //name has no color
+						{
+							wcscat(newName, L"c51bbc4ff");
+							wcscat(newName, oldName);
 
-						wcscat(newName, oldName);
+						}
 
 						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_SETTEXT, 0, (LPARAM)newName);
 					}
@@ -1089,6 +1110,27 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 							SendDlgItemMessage(ghw_tab1, IDT_ABIL_FINI, WM_SETTEXT, 0, (LPARAM)_T("98"));
 							SendDlgItemMessage(ghw_tab1, IDT_ABIL_DRIB, WM_SETTEXT, 0, (LPARAM)_T("89"));
 						}*/
+
+						wchar_t oldName[0x1000];
+						wchar_t newName[0x1000];
+
+						//this is to remove any name colors that may have been added via the gold/silver player option
+
+						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_GETTEXT, (WPARAM)(sizeof(oldName) / sizeof(oldName[0])), (LPARAM)oldName);
+
+						newName[0] = 0;
+						if (wcsncmp(oldName, L"ccc9900ff", 10) == 0 || wcsncmp(oldName, L"c51bbc4ff", 10) == 0 ) //name starts with gold or silver color
+						{
+							std::wstring tempName(oldName);
+							tempName = tempName.substr(10); //remove the color
+							wcscat(newName, tempName.c_str());
+						}
+						else //the name doesn't have a color
+						{
+							wcscat(newName, oldName);
+						}
+
+						SendDlgItemMessage(ghw_main, IDT_PLAY_NAME, WM_SETTEXT, 0, (LPARAM)newName);
 					}
 				}
 				break;

--- a/VTL7/pes16.cpp
+++ b/VTL7/pes16.cpp
@@ -492,7 +492,31 @@ void fill_team_tactics16(int &current_byte, void* ghdescriptor, team_entry* gtea
 	current_byte+=0x1FA;
 
 	gteams[t_ind].captain_ind = (char)pDescriptorOld->data[current_byte];
-	current_byte+=0xA;
+	current_byte-=0x18B;
+	for(int ii=0; ii<11; ii++)
+	{
+	gteams[t_ind].ManMarking1[ii] = pDescriptorOld->data[current_byte];
+	current_byte++;
+	}
+	current_byte+=0x70;
+	for(int ii=0; ii<11; ii++)
+	{
+	gteams[t_ind].ManMarking2[ii] = pDescriptorOld->data[current_byte];
+	current_byte++;
+	}
+	current_byte+=0x70;
+	for(int ii=0; ii<11; ii++)
+	{
+	gteams[t_ind].ManMarking3[ii] = pDescriptorOld->data[current_byte];
+	current_byte++;
+	}
+	current_byte+=0x8E;
+	gteams[t_ind].AutoSub = pDescriptorOld->data[current_byte];
+	current_byte++;
+	gteams[t_ind].AutoOffside = pDescriptorOld->data[current_byte];
+	current_byte++;
+	gteams[t_ind].AutoPresetTactics = pDescriptorOld->data[current_byte];
+	current_byte+=0x4;
 }
 
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
aatf checks that all support settings are off and that man marking settings are not used if using a pes 16 save. Also fixed swap/copy player stats so it no longer changes the free kick animation.