### PR TITLE
Gold/silver button captain bonus

### DIFF
--- a/VTL7/main.cpp
+++ b/VTL7/main.cpp
@@ -883,6 +883,32 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 
 						SendDlgItemMessage(ghw_main, IDT_PLAY_HGT, WM_SETTEXT, 0, (LPARAM)_T("183"));
 
+						//check if the player is captain, and give them +1 all stats if they are
+						if (gn_teamsel > -1) //prevents a crash if button pressed with no team selected
+						{
+							if (gteams[gplayers[gn_playind[gn_listsel]].team_ind].captain_ind == gplayers[gn_playind[gn_listsel]].team_lineup_ind) 
+							{
+								int ii;
+								TCHAR buffer[3];
+								for (ii = IDT_ABIL_ATKP; ii < gi_lastAbility; ii += 2)
+								{
+									wchar_t skill[0x1000];
+
+									SendDlgItemMessage(ghw_tab1, ii, WM_GETTEXT, (WPARAM)(sizeof(skill) / sizeof(skill[0])), (LPARAM)skill);
+
+									int skillNum = wcstol(skill, 0, 10);
+									skillNum += 1;
+
+									wchar_t newSkill[0x1000];
+									swprintf_s(newSkill, L"%d", skillNum);
+
+									wprintf(L"%s\n", newSkill);
+
+									SendDlgItemMessage(ghw_tab1, ii, WM_SETTEXT, 0, (LPARAM)newSkill);
+								}
+							}
+						}
+
 						Button_SetCheck(GetDlgItem(ghw_tab1, IDB_SKIL_LTHR), 0);
 
 						/*if (heightNum == 187 || heightNum == 194)
@@ -936,6 +962,32 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 						int heightNum = wcstol(height, 0, 10); */
 
 						SendDlgItemMessage(ghw_main, IDT_PLAY_HGT, WM_SETTEXT, 0, (LPARAM)_T("185"));
+
+						//check if the player is captain, and give them +1 all stats if they are
+						if (gn_teamsel > -1) //prevents a crash if button pressed with no team selected
+						{
+							if (gteams[gplayers[gn_playind[gn_listsel]].team_ind].captain_ind == gplayers[gn_playind[gn_listsel]].team_lineup_ind)
+							{
+								int ii;
+								TCHAR buffer[3];
+								for (ii = IDT_ABIL_ATKP; ii < gi_lastAbility; ii += 2)
+								{
+									wchar_t skill[0x1000];
+
+									SendDlgItemMessage(ghw_tab1, ii, WM_GETTEXT, (WPARAM)(sizeof(skill) / sizeof(skill[0])), (LPARAM)skill);
+
+									int skillNum = wcstol(skill, 0, 10);
+									skillNum += 1;
+
+									wchar_t newSkill[0x1000];
+									swprintf_s(newSkill, L"%d", skillNum);
+
+									wprintf(L"%s\n", newSkill);
+
+									SendDlgItemMessage(ghw_tab1, ii, WM_SETTEXT, 0, (LPARAM)newSkill);
+								}
+							}
+						}
 
 						Button_SetCheck(GetDlgItem(ghw_tab1, IDB_SKIL_LTHR), 0);
 
@@ -1106,7 +1158,8 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 					}
 				}
 				break;
-				case IDB_MAKE_CAPT:
+
+				/*case IDB_MAKE_CAPT: //no longer needed as make gold/silver buttons do this
 				{
 					if (HIWORD(W) == BN_CLICKED)
 					{
@@ -1129,7 +1182,7 @@ LRESULT CALLBACK wnd_proc(HWND H, UINT M, WPARAM W, LPARAM L)
 							SendDlgItemMessage(ghw_tab1, ii, WM_SETTEXT, 0, (LPARAM)newSkill);
 						}
 					}
-				}
+				}*/
 				break;
 				case IDM_DATA_AATFC: //Run AATF on currently-selected team and show results in a dialog box
 				{

--- a/VTL7/window.cpp
+++ b/VTL7/window.cpp
@@ -48,19 +48,20 @@ void setup_main(HWND H)
 		20, 552, 250, 26, H, (HMENU)IDB_MAKE_SILV, GetModuleHandle(NULL), NULL);	
 	setup_control(hw_new, ghFont, scale_cntl_proc);
 
-	hw_new = CreateWindowEx(0, _T("Button"), _T("Regular"), 
-		BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 
-		20, 584, 60, 26, H, (HMENU)IDB_MAKE_REGU, GetModuleHandle(NULL), NULL);
+	hw_new = CreateWindowEx(0, _T("Button"), _T("Regular"),
+		BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP,
+		20, 584, 100, 26, H, (HMENU)IDB_MAKE_REGU, GetModuleHandle(NULL), NULL);
 	setup_control(hw_new, ghFont, scale_cntl_proc);
 
-	hw_new = CreateWindowEx(0, _T("Button"), _T("Captain"),
+	/*hw_new = CreateWindowEx(0, _T("Button"), _T("Captain"), //hidden as no longer used
 		BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP,
 		80, 584, 60, 26, H, (HMENU)IDB_MAKE_CAPT, GetModuleHandle(NULL), NULL);
 	setup_control(hw_new, ghFont, scale_cntl_proc);
+	*/
 
 	hw_new = CreateWindowEx(0, _T("Button"), _T("Set Stats"),
 		BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP,
-		140, 584, 80, 26, H, (HMENU)IDB_SET_STATS, GetModuleHandle(NULL), NULL);
+		120, 584, 100, 26, H, (HMENU)IDB_SET_STATS, GetModuleHandle(NULL), NULL);
 	setup_control(hw_new, ghFont, scale_cntl_proc);
 
 	hw_new = CreateWindowEx(WS_EX_CLIENTEDGE, _T("EDIT"), _T(""), 


### PR DESCRIPTION
Make gold/silver buttons now check if the player is the captain and gives them +1 all stats if they are. Commented out the "Captain" button that previously gave +1 stats as it's no longer needed.